### PR TITLE
bump core action version to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Anes Belfodil",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.5",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/tool-cache": "^1.6.0",
     "uuid": "^8.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,15 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.3", "@actions/core@^1.2.5":
+"@actions/core@^1.2.3":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.5.tgz#fa57bf8c07a38191e243beb9ea9d8368c1cb02c8"
   integrity sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg==
+
+"@actions/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
+  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
 
 "@actions/exec@^1.0.0", "@actions/exec@^1.0.4":
   version "1.0.4"


### PR DESCRIPTION
This should remedy the `add-path` issue I was seeing when utilizing this action:
```
Error: Unable to process command '::add-path::/opt/hostedtoolcache/dart-plugins/2.10.2/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```